### PR TITLE
Add missing permissions leading to crash on startup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     
     <application


### PR DESCRIPTION
- WAKE_LOCK is required for acquiring wifi lock
  - https://github.com/alvr-org/ALVR/blob/2a43bb9c3e12845c132ae8f1b2963b8c78c3c330/alvr/client_core/src/platform/android.rs#L186-L198
- ACCESS_WIFI_STATE for getting wifi state
  - https://github.com/alvr-org/ALVR/blob/2a43bb9c3e12845c132ae8f1b2963b8c78c3c330/alvr/client_core/src/platform/android.rs#L149-L159
  
for.eg.
```java
04:24:28.502  3683-3683  [ALVR NATIVE-RUST]      pid-3683                             E  acquiring wifi lock failed with error Type:JavaException
04:24:28.503  3683-3683  lient.cardboar          pid-3683                             A  thread.cc:2361] No pending exception expected: java.lang.SecurityException: Neither user 10371 nor current process has android.permission.WAKE_LOCK.
	 thread.cc:2361] (Throwable with no stack trace)
	 thread.cc:2361] Caused by: android.os.RemoteException: Remote stack trace:
	 thread.cc:2361] 	at android.app.ContextImpl.enforce(ContextImpl.java:2209)
	 thread.cc:2361] 	at android.app.ContextImpl.enforceCallingOrSelfPermission(ContextImpl.java:2237)
	 thread.cc:2361] 	at android.content.ContextWrapper.enforceCallingOrSelfPermission(ContextWrapper.java:907)
	 thread.cc:2361] 	at com.android.server.wifi.WifiServiceImpl.acquireWifiLock(WifiServiceImpl.java:3920)
	 thread.cc:2361] 	at android.net.wifi.IWifiManager$Stub.onTransact(IWifiManager.java:1044)
	 thread.cc:2361] 
	 thread.cc:2361] (Throwable with no stack trace)
	 thread.cc:2361] 
04:24:28.508  3683-3707  [ALVR NATIVE-RUST]      pid-3683                             E  What happened:
	 panicked at 'called `Result::unwrap()` on an `Err` value: JavaException', alvr\client_core\src\platform\android.rs:157:10
	 
	 Backtrace:
		0: <unknown>
		1: <unknown>
		2: <unknown>
		3: <unknown>
		4: <unknown>
		5: <unknown>
		6: <unknown>
		7: <unknown>
		8: <unknown>
		9: <unknown>
	   10: <unknown>
	   11: <unknown>
	   12: <unknown>
	   13: <unknown>
	   14: <unknown>
	   15: <unknown>
```